### PR TITLE
fix: progress don't stop on pause bug and pause at first and last story

### DIFF
--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -15,13 +15,13 @@ export default function () {
     let mousedownId = useRef<any>();
     let isMounted = useRef<boolean>(true);
 
-    const { width, height, loop, currentIndex, isPaused, keyboardNavigation, preventDefault, storyContainerStyles = {} } = useContext<GlobalCtx>(GlobalContext);
+    const { width, height, loop, currentIndex, isPaused, keyboardNavigation, preventDefault, storyContainerStyles = {}, onAllStoriesEnd } = useContext<GlobalCtx>(GlobalContext);
     const { stories } = useContext<StoriesContextInterface>(StoriesContext);
 
     useEffect(() => {
         if (typeof currentIndex === 'number') {
             if (currentIndex >= 0 && currentIndex < stories.length) {
-                setCurrentIdWrapper(() => currentIndex)
+                setCurrentId(() => currentIndex)
             } else {
                 console.error('Index out of bounds. Current index was set to value more than the length of stories array.', currentIndex)
             }
@@ -65,13 +65,10 @@ export default function () {
         setBufferAction(!!bufferAction)
     }
 
-    const setCurrentIdWrapper = (callback) => {
-        setCurrentId(callback);
-        toggleState('pause', true);
-    }
-
     const previous = () => {
-        setCurrentIdWrapper(prev => prev > 0 ? prev - 1 : prev)
+        if(currentId !== 0){
+            setCurrentId(prev =>  prev - 1)
+        }
     }
 
     const next = () => {
@@ -85,14 +82,15 @@ export default function () {
     };
 
     const updateNextStoryIdForLoop = () => {
-        setCurrentIdWrapper(prev => (prev + 1) % stories.length)
+        setCurrentId(prev => (prev + 1) % stories.length)
     }
 
     const updateNextStoryId = () => {
-        setCurrentIdWrapper(prev => {
-            if (prev < stories.length - 1) return prev + 1
-            return prev
-        })
+        if(currentId < stories.length - 1){
+            setCurrentId(prev => prev + 1)
+        } else{
+            onAllStoriesEnd()
+        }
     }
 
     const debouncePause = (e: React.MouseEvent | React.TouchEvent) => {

--- a/src/components/ProgressArray.tsx
+++ b/src/components/ProgressArray.tsx
@@ -6,6 +6,9 @@ import GlobalContext from './../context/Global'
 import StoriesContext from './../context/Stories'
 
 export default () => {
+    let animationFrameId = useRef<number>()
+    const pauseRef = useRef(false);
+
     const [count, setCount] = useState<number>(0)
     const { currentId, next, videoDuration, pause } = useContext<ProgressContext>(ProgressCtx)
     const { defaultInterval, onStoryEnd, onStoryStart, onAllStoriesEnd } = useContext<GlobalCtx>(GlobalContext);
@@ -16,6 +19,7 @@ export default () => {
     }, [currentId, stories])
 
     useEffect(() => {
+        pauseRef.current = pause
         if (!pause) {
             animationFrameId.current = requestAnimationFrame(incrementCount)
         }
@@ -24,11 +28,10 @@ export default () => {
         }
     }, [currentId, pause])
 
-    let animationFrameId = useRef<number>()
-
     let countCopy = count;
     const incrementCount = () => {
         if (countCopy === 0) storyStartCallback()
+        if (pauseRef.current) return
         setCount((count: number) => {
             const interval = getCurrentInterval()
             countCopy = count + (100 / ((interval / 1000) * 60))
@@ -65,13 +68,13 @@ export default () => {
     }
 
     return (
-        <div style={styles.progressArr}>
+        <div style={{...styles.progressArr, filter: !pauseRef.current ?'drop-shadow(0 1px 8px #222)': 'none'}}>
             {stories.map((_, i) =>
                 <Progress
-                    key={i}
-                    count={count}
-                    width={1 / stories.length}
-                    active={i === currentId ? 1 : (i < currentId ? 2 : 0)}
+                key={i}
+                count={count}
+                width={1 / stories.length}
+                active={i === currentId ? 1 : (i < currentId ? 2 : 0)}
                 />)}
         </div>
     )
@@ -89,6 +92,5 @@ const styles = {
         paddingTop: 7,
         alignSelf: 'center',
         zIndex: 1001,
-        filter: 'drop-shadow(0 1px 8px #222)'
     }
 }

--- a/src/components/ProgressArray.tsx
+++ b/src/components/ProgressArray.tsx
@@ -71,10 +71,10 @@ export default () => {
         <div style={{...styles.progressArr, filter: !pauseRef.current ?'drop-shadow(0 1px 8px #222)': 'none'}}>
             {stories.map((_, i) =>
                 <Progress
-                key={i}
-                count={count}
-                width={1 / stories.length}
-                active={i === currentId ? 1 : (i < currentId ? 2 : 0)}
+                    key={i}
+                    count={count}
+                    width={1 / stories.length}
+                    active={i === currentId ? 1 : (i < currentId ? 2 : 0)}
                 />)}
         </div>
     )


### PR DESCRIPTION
*why I did*
- pause the story when click on `see more` zone but the progress bar still running
- when click on the left screen of first story. Stories become pause.
- when click on the right screen of first story. Stories become pause.

*What i do*
- using useRef instead useState to check pause because of closure issue https://stackoverflow.com/questions/62806541/how-to-solve-the-react-hook-closure-issue
- remove pause when story changes to another story so fix stories become pause problems.
- call `onAllStoryEnd` when click at right side of last story